### PR TITLE
Implement remaining changes of #27

### DIFF
--- a/src/app/components/actionbar/actionbar.component.html
+++ b/src/app/components/actionbar/actionbar.component.html
@@ -149,6 +149,15 @@
         </button>
       </div>
     }
+    <!-- Switch to detail page -->
+    @if (isAnnotateUrl$ | async) {
+      <div>
+        <button mat-flat-button color="primary" [routerLink]="detailPageLink()">
+          <mat-icon>visibility</mat-icon>
+          {{ 'Show entity' | translate }}
+        </button>
+      </div>
+    }
 
     <!-- Edit Entity settings -->
     @if (showEditButton() && isEntity() && isEditingAllowed()) {

--- a/src/app/components/actionbar/actionbar.component.html
+++ b/src/app/components/actionbar/actionbar.component.html
@@ -221,17 +221,6 @@
           <mat-icon>perm_media</mat-icon>
         </button>
       </div>
-      @if (isEntity()) {
-        <div
-          [matTooltip]="
-            (isDownloadable() ? 'Download model files' : 'Download not available') | translate
-          "
-        >
-          <button mat-icon-button (click)="openDownloadDialog()" [disabled]="!isDownloadable()">
-            <mat-icon>file_download</mat-icon>
-          </button>
-        </div>
-      }
       @if (metadataDownload(); as metadataDownload) {
         <a
           [href]="metadataDownload.url"
@@ -249,6 +238,17 @@
           <mat-icon>content_copy</mat-icon>
         </button>
       </div>
+      @if (isEntity()) {
+        <div
+          [matTooltip]="
+            (isDownloadable() ? 'Download model files' : 'Download not available') | translate
+          "
+        >
+          <button mat-icon-button (click)="openDownloadDialog()" [disabled]="!isDownloadable()">
+            <mat-icon>file_download</mat-icon>
+          </button>
+        </div>
+      }
     }
   </div>
 </mat-toolbar>
@@ -256,25 +256,21 @@
 <mat-menu #usedInCompilationsMenu="matMenu">
   @for (compilation of selectHistory.usedInCompilations.compilations; track compilation._id) {
     <button class="used-in-collections-button" mat-menu-item (click)="navigate(compilation)">
-      <p style="margin: 0">
-        <mat-icon matTooltip="{{ 'View collection' | translate }}"> folder_special </mat-icon>
-        @if (isRecentlyAnnotated(compilation)) {
-          <mat-icon
-            matTooltip="{{
-              'The current object has been recently annotated in this collection.' | translate
-            }}"
-            >access_time</mat-icon
-          >
-        }
-        @if (isAnnotatedInCompilation(compilation)) {
-          <mat-icon
-            matTooltip="{{ 'The current object is annotated in this collection.' | translate }}"
-          >
-            label
-          </mat-icon>
-        }
-        {{ compilation.name }}
-      </p>
+      <mat-icon [matTooltip]="'View collection' | translate"> folder_special </mat-icon>
+      @if (isRecentlyAnnotated(compilation)) {
+        <mat-icon
+          [matTooltip]="
+            'The current object has been recently annotated in this collection' | translate
+          "
+          >access_time</mat-icon
+        >
+      }
+      @if (isAnnotatedInCompilation(compilation)) {
+        <mat-icon [matTooltip]="'The current object is annotated in this collection' | translate">
+          label
+        </mat-icon>
+      }
+      {{ compilation.name }}
     </button>
   }
 </mat-menu>

--- a/src/app/components/actionbar/actionbar.component.ts
+++ b/src/app/components/actionbar/actionbar.component.ts
@@ -4,7 +4,7 @@ import { Component, computed, EventEmitter, input, Output, signal } from '@angul
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 import { AsyncPipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
@@ -19,7 +19,6 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { FilesizePipe } from 'src/app/pipes';
 import {
   AccountService,
   AllowAnnotatingService,
@@ -63,7 +62,6 @@ import { TranslatePipe } from '../../pipes/translate.pipe';
     MatMenuModule,
     AsyncPipe,
     TranslatePipe,
-    FilesizePipe,
   ],
 })
 export class ActionbarComponent {
@@ -93,6 +91,8 @@ export class ActionbarComponent {
   });
   isEntity = computed(() => isEntity(this.element()));
   isCompilation = computed(() => isCompilation(this.element()));
+
+  isAnnotateUrl$ = this.activatedRoute.url.pipe(map(url => url.at(0)?.path === 'annotate'));
 
   metadataDownload = computed(() => {
     const element = this.element();
@@ -249,6 +249,7 @@ export class ActionbarComponent {
     private dialogHelper: DialogHelperService,
     private quickAdd: QuickAddService,
     private router: Router,
+    private activatedRoute: ActivatedRoute,
     private sanitizer: DomSanitizer,
     public selectHistory: SelectHistoryService,
     private snackbar: SnackbarService,
@@ -349,6 +350,14 @@ export class ActionbarComponent {
       ? isEntity(element)
         ? ['/annotate', 'entity', element._id]
         : ['/annotate', 'compilation', element._id]
+      : ['/explore'];
+  });
+  detailPageLink = computed(() => {
+    const element = this.element();
+    return element
+      ? isEntity(element)
+        ? ['/entity', element._id]
+        : ['/compilation', element._id]
       : ['/explore'];
   });
 

--- a/src/app/pages/annotate/annotate.component.html
+++ b/src/app/pages/annotate/annotate.component.html
@@ -1,4 +1,4 @@
-<app-actionbar [showEditButton]="true" [element]="entity"></app-actionbar>
+<app-actionbar [showEditButton]="true" [showUsesInCollection]="true" [element]="entity" />
 
 @if (object) {
   <!-- Model ID provided: Show viewer -->


### PR DESCRIPTION
Download button is now the last button in the action bar, and the "used in collections" menu button is now shown when on the annotate-page

<img width="470" height="157" alt="image" src="https://github.com/user-attachments/assets/880f6732-f2e7-4f88-82d3-95398ae9c502" />
